### PR TITLE
accounting journal: add more attributes

### DIFF
--- a/oda_wd_client/service/financial_management/api.py
+++ b/oda_wd_client/service/financial_management/api.py
@@ -15,6 +15,7 @@ from oda_wd_client.service.financial_management.types import (
     SpendCategory,
 )
 from oda_wd_client.service.financial_management.utils import (
+    get_business_process_parameters,
     pydantic_accounting_journal_to_workday,
     pydantic_conversion_rate_to_workday,
     workday_company_to_pydantic,
@@ -122,9 +123,11 @@ class FinancialManagement(WorkdayClient):
                 )
 
     def submit_accounting_journal(
-        self, journal: AccountingJournalData
+        self, journal: AccountingJournalData, auto_complete: bool = True
     ) -> sudsobject.Object:
-        data_object = pydantic_accounting_journal_to_workday(journal, client=self)
+        accounting_journal_data_object = pydantic_accounting_journal_to_workday(journal, client=self)
+        business_process_parameters = get_business_process_parameters(auto_complete=auto_complete, client=self)
+
         return self._request(
-            "Submit_Accounting_Journal", Accounting_Journal_Data=data_object
+            "Submit_Accounting_Journal", Accounting_Journal_Data=accounting_journal_data_object, Business_Process_Parameters=business_process_parameters
         )

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -191,8 +191,4 @@ class AccountingJournalData(BaseModel):
     journal_source: JournalSource
     journal_entry_line_data: list[JournalEntryLineData]
     memo: str | None = None
-    submit: bool = False
-
-    @property
-    def accounting_journal_id(self):
-        return f"{self.accounting_date.strftime('%Y%m%d')}-{self.company.workday_id}"
+    submit: bool | None = None

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -193,3 +193,4 @@ class AccountingJournalData(BaseModel):
     memo: str | None = None
     submit: bool | None = None
     auto_complete: bool | None = None
+    accounting_journal_id: str

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -191,6 +191,7 @@ class AccountingJournalData(BaseModel):
     journal_source: JournalSource
     journal_entry_line_data: list[JournalEntryLineData]
     memo: str | None = None
+    submit: bool = False
 
     @property
     def accounting_journal_id(self):

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -192,3 +192,4 @@ class AccountingJournalData(BaseModel):
     journal_entry_line_data: list[JournalEntryLineData]
     memo: str | None = None
     submit: bool | None = None
+    auto_complete: bool | None = None

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -194,4 +194,4 @@ class AccountingJournalData(BaseModel):
 
     @property
     def accounting_journal_id(self):
-        return f"{self.accounting_date.strftime('%Y%m%d')}-{self.company.workday_id}-v2"
+        return f"{self.accounting_date.strftime('%Y%m%d')}-{self.company.workday_id}"

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -192,5 +192,4 @@ class AccountingJournalData(BaseModel):
     journal_entry_line_data: list[JournalEntryLineData]
     memo: str | None = None
     submit: bool | None = None
-    auto_complete: bool | None = None
     accounting_journal_id: str

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -194,4 +194,4 @@ class AccountingJournalData(BaseModel):
 
     @property
     def accounting_journal_id(self):
-        return f"{self.accounting_date.strftime('%Y%m%d')}-{self.company.workday_id}"
+        return f"{self.accounting_date.strftime('%Y%m%d')}-{self.company.workday_id}-v2"

--- a/oda_wd_client/service/financial_management/types.py
+++ b/oda_wd_client/service/financial_management/types.py
@@ -190,6 +190,7 @@ class AccountingJournalData(BaseModel):
     ledger_type: LedgerType
     journal_source: JournalSource
     journal_entry_line_data: list[JournalEntryLineData]
+    memo: str | None = None
 
     @property
     def accounting_journal_id(self):

--- a/oda_wd_client/service/financial_management/utils.py
+++ b/oda_wd_client/service/financial_management/utils.py
@@ -242,6 +242,7 @@ def pydantic_accounting_journal_to_workday(
         )
     if journal.memo:
         wd_accounting_journal.Journal_Entry_Memo = journal.memo
+
     wd_accounting_journal.Company_Reference = journal.company.wd_object(client)
     wd_accounting_journal.Ledger_Type_Reference = journal.ledger_type.wd_object(client)
     for journal_entry_line_data in journal.journal_entry_line_data:

--- a/oda_wd_client/service/financial_management/utils.py
+++ b/oda_wd_client/service/financial_management/utils.py
@@ -246,11 +246,6 @@ def pydantic_accounting_journal_to_workday(
     if journal.submit:
         wd_accounting_journal.Submit = journal.submit
 
-    if journal.auto_complete:
-        financials_business_process_parameters = client.factory("ns0:Financials_Business_Process_ParametersType")
-        financials_business_process_parameters.Auto_Complete = journal.auto_complete
-        wd_accounting_journal.Financials_Business_Process_Parameters = financials_business_process_parameters
-
     wd_accounting_journal.Company_Reference = journal.company.wd_object(client)
     wd_accounting_journal.Ledger_Type_Reference = journal.ledger_type.wd_object(client)
     for journal_entry_line_data in journal.journal_entry_line_data:
@@ -260,3 +255,8 @@ def pydantic_accounting_journal_to_workday(
         wd_accounting_journal.Journal_Entry_Line_Replacement_Data.append(wd_data)
 
     return wd_accounting_journal
+
+def get_business_process_parameters(auto_complete: bool, client: WorkdayClient) -> sudsobject.Object:
+    financials_business_process_parameters = client.factory("ns0:Financials_Business_Process_ParametersType")
+    financials_business_process_parameters.Auto_Complete = auto_complete
+    return financials_business_process_parameters

--- a/oda_wd_client/service/financial_management/utils.py
+++ b/oda_wd_client/service/financial_management/utils.py
@@ -240,6 +240,8 @@ def pydantic_accounting_journal_to_workday(
         wd_accounting_journal.Currency_Reference = journal.company.currency.wd_object(
             client
         )
+    if journal.memo:
+        wd_accounting_journal.Journal_Entry_Memo = journal.memo
     wd_accounting_journal.Company_Reference = journal.company.wd_object(client)
     wd_accounting_journal.Ledger_Type_Reference = journal.ledger_type.wd_object(client)
     for journal_entry_line_data in journal.journal_entry_line_data:

--- a/oda_wd_client/service/financial_management/utils.py
+++ b/oda_wd_client/service/financial_management/utils.py
@@ -243,6 +243,9 @@ def pydantic_accounting_journal_to_workday(
     if journal.memo:
         wd_accounting_journal.Journal_Entry_Memo = journal.memo
 
+    if journal.submit:
+        wd_accounting_journal.Submit = journal.submit
+
     wd_accounting_journal.Company_Reference = journal.company.wd_object(client)
     wd_accounting_journal.Ledger_Type_Reference = journal.ledger_type.wd_object(client)
     for journal_entry_line_data in journal.journal_entry_line_data:

--- a/oda_wd_client/service/financial_management/utils.py
+++ b/oda_wd_client/service/financial_management/utils.py
@@ -246,6 +246,11 @@ def pydantic_accounting_journal_to_workday(
     if journal.submit:
         wd_accounting_journal.Submit = journal.submit
 
+    if journal.auto_complete:
+        financials_business_process_parameters = client.factory("ns0:Financials_Business_Process_ParametersType")
+        financials_business_process_parameters.Auto_Complete = journal.auto_complete
+        wd_accounting_journal.Financials_Business_Process_Parameters = financials_business_process_parameters
+
     wd_accounting_journal.Company_Reference = journal.company.wd_object(client)
     wd_accounting_journal.Ledger_Type_Reference = journal.ledger_type.wd_object(client)
     for journal_entry_line_data in journal.journal_entry_line_data:


### PR DESCRIPTION
1. Adding support for journal level memo `Journal_Entry_Memo` (https://community.workday.com/sites/default/files/file-hosting/productionapi/Financial_Management/v40.2/Submit_Accounting_Journal.html)
2. Adding support for Submit (https://community.workday.com/sites/default/files/file-hosting/productionapi/Financial_Management/v40.2/Submit_Accounting_Journal.html#Accounting_Journal_DataType)
3. Adding support for Financials_Business_Process_Parameters  (https://community.workday.com/sites/default/files/file-hosting/productionapi/Financial_Management/v40.2/Submit_Accounting_Journal.html#Financials_Business_Process_ParametersType)
4. Refactoring: accounting_journal_id is no longer set here (should be passed in)