### PR TITLE
🚑️ fix: Set supplier's invoice number only

### DIFF
--- a/oda_wd_client/service/resource_management/utils.py
+++ b/oda_wd_client/service/resource_management/utils.py
@@ -270,7 +270,8 @@ def pydantic_supplier_invoice_to_workday(
     invoice_data.Submit = invoice.submit
     invoice_data.Locked_in_Workday = invoice.locked_in_workday
 
-    invoice_data.Invoice_Number = invoice.invoice_number
+    # We want to let workday set the invoice number, but keep the invoice's number for supplier's invoice number
+    invoice_data.Invoice_Number = None
     invoice_data.Suppliers_Invoice_Number = invoice.invoice_number
     invoice_data.Company_Reference = invoice.company.wd_object(client)
     invoice_data.Currency_Reference = invoice.currency.wd_object(client)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda-wd-client"
-version = "0.0.15"
+version = "0.0.16"
 description = "A library for interacting with Workday from Python"
 authors = [
     "Karl Fredrik Haugland <karlfredrik.haugland@oda.com>",


### PR DESCRIPTION
Workday has two fields for invoice number, we want to set suppliers invoice number and not the invoice number field. This allows Workday to generate the invoice number, but keep the original invoice number for bookkeeping and processing